### PR TITLE
Support new github actions macOS environment and improve something.

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,17 +1,17 @@
 name: "E2E test"
-on: [push]
+on: [pull_request]
 
 jobs:
   check_install:
     strategy:
       fail-fast: false
-      max-parallel: 3
       matrix:
         os: [macos-latest]
-        xcode: ["10.0", "10.1", "10.2.1", "10.3", "11.0", "11.1", "11.2"]
+        xcode: ["10.0", "10.1", "10.2.1", "10.3", "11.0", "11.1", "11.2.1"]
 
     runs-on: ${{ matrix.os }}
     env:
+      # It needs AppleID that has disabled 2FA.
       XCODE_INSTALL_USER: ${{ secrets.XCODE_INSTALL_USER }}
       XCODE_INSTALL_PASSWORD: ${{ secrets.XCODE_INSTALL_PASSWORD }}
     steps:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -32,9 +32,10 @@ jobs:
     # Prepare
     - run: bundle install -j4 --clean --path=vendor
     - run: bundle exec xcversion update
-    - run: bundle exec xcversion uninstall ${{ matrix.xcode }}
     - name: Show installed versions before install
       run: bundle exec xcversion installed
+    - name: Uninstall installed target Xcode version
+      run: bundle exec xcversion uninstall ${{ matrix.xcode }} || true
 
     # Exec
     - run: bundle exec xcversion install ${{ matrix.xcode }}


### PR DESCRIPTION
GitHub Actions macOS environment was updated to Catalina and uninstalled Xcode 10.x. Our actions `xcversions uninstall` step will need to error handling when target is uninstalled version.
https://github.blog/changelog/2019-11-06-github-actions-macos-virtual-environment-updated-to-catalina/


Other fixes

- Change github actions trigger "push" to "pull_request"
- Remove parallel limit for speed up test
- Replace deprecated Xcode 10.2 to 10.2.1